### PR TITLE
Fix code sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ function add64(stdlib, buffer, aIndex, bIndex) {
   bIndex = bIndex|0;
   var aValue = values[aIndex>>3];
   var bValue = values[bIndex>>3];
-  return cast(64, a + b);
+  return cast(64, aValue + bValue);
 }
 ```
 


### PR DESCRIPTION
Not entirely sure I'm reading it right, but `a` and `b` aren't in scope, whereas `aValue` and `bValue` are.